### PR TITLE
 Add a logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/teleop_modular_logo.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/teleop_modular_logo_dark.svg">
+    <img src="docs/assets/teleop_modular_logo.svg" width="200px" alt="teleop_modular logo">
+  </picture>
+</p>
+
 # teleop_modular
 
 `teleop_modular` is a generalized framework for teleoperation input handling in ROS2.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<p align="center">
+<div align="center">
   <picture>
     <source media="(prefers-color-scheme: light)" srcset="docs/assets/teleop_modular_logo.svg">
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/teleop_modular_logo_dark.svg">
     <img src="docs/assets/teleop_modular_logo.svg" width="200px" alt="teleop_modular logo">
   </picture>
-</p>
+</div>
 
 # teleop_modular
 

--- a/docs/assets/teleop_modular_logo.svg
+++ b/docs/assets/teleop_modular_logo.svg
@@ -1,0 +1,29 @@
+<svg width="274" height="210" viewBox="0 0 274 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="274" height="210"/>
+  <g clip-path="url(#clip0_6_133)">
+    <circle cx="80.7078" cy="49" r="16" fill="#334066"/>
+    <circle cx="136.708" cy="105" r="16" fill="#334066"/>
+    <circle cx="192.708" cy="49" r="16" fill="#334066"/>
+    <g clip-path="url(#clip1_6_133)">
+      <circle cx="192.708" cy="105" r="16" fill="#334066"/>
+      <circle cx="192.708" cy="105" r="10" fill="white"/>
+    </g>
+    <circle cx="192.708" cy="161" r="16" fill="#334066"/>
+    <path d="M80.7078 58V105H108.708" stroke="#334066" stroke-width="6"/>
+    <path d="M108.708 100L115.708 105L108.708 110V100Z" stroke="#334066" stroke-width="6"/>
+    <path d="M164.708 100L171.708 105L164.708 110V100Z" stroke="#334066" stroke-width="6"/>
+    <path d="M164.708 44L171.708 49L164.708 54V44Z" stroke="#334066" stroke-width="6"/>
+    <path d="M136.708 94V49H165.708" stroke="#334066" stroke-width="6"/>
+    <path d="M136.708 145C136.708 145 109.208 145 107.708 145C91.2078 145 58.7078 210.364 35.7078 202C12.7078 193.636 2.70781 182.5 8.70782 145C14.7078 107.5 35.7078 30 53.2078 18.5C70.7078 7 84.2078 7 95.2078 7C106.208 7 123.708 25 136.708 25H158.5" stroke="#334066" stroke-width="6" stroke-linecap="round"/>
+    <path d="M237.792 202C260.792 193.636 270.792 182.5 264.792 145C258.792 107.5 237.792 30.0001 220.292 18.5001" stroke="#334066" stroke-width="6" stroke-linecap="round"/>
+    <path d="M148.708 105H163.208" stroke="#334066" stroke-width="6"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_6_133">
+      <rect width="266" height="202" fill="white" transform="translate(4 4)"/>
+    </clipPath>
+    <clipPath id="clip1_6_133">
+      <rect width="32" height="32" fill="white" transform="translate(176.708 89)"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/docs/assets/teleop_modular_logo_dark.svg
+++ b/docs/assets/teleop_modular_logo_dark.svg
@@ -1,28 +1,28 @@
 <svg width="274" height="210" viewBox="0 0 274 210" fill="none" xmlns="http://www.w3.org/2000/svg">
   <rect width="274" height="210"/>
   <g clip-path="url(#clip0_7_135)">
-    <circle cx="80.7078" cy="49" r="16" fill="white"/>
-    <circle cx="136.708" cy="105" r="16" fill="white"/>
-    <circle cx="192.708" cy="49" r="16" fill="white"/>
+    <circle cx="80.7078" cy="49" r="16" fill="#D1D7E0"/>
+    <circle cx="136.708" cy="105" r="16" fill="#D1D7E0"/>
+    <circle cx="192.708" cy="49" r="16" fill="#D1D7E0"/>
     <g clip-path="url(#clip1_7_135)">
-      <circle cx="192.708" cy="105" r="13" stroke="white" stroke-width="6"/>
+      <circle cx="192.708" cy="105" r="13" stroke="#D1D7E0" stroke-width="6"/>
     </g>
-    <circle cx="192.708" cy="161" r="16" fill="white"/>
-    <path d="M80.7078 58V105H108.708" stroke="white" stroke-width="6"/>
-    <path d="M108.708 100L115.708 105L108.708 110V100Z" stroke="white" stroke-width="6"/>
-    <path d="M164.708 100L171.708 105L164.708 110V100Z" stroke="white" stroke-width="6"/>
-    <path d="M164.708 44L171.708 49L164.708 54V44Z" stroke="white" stroke-width="6"/>
-    <path d="M136.708 94V49H165.708" stroke="white" stroke-width="6"/>
-    <path d="M136.708 145C136.708 145 109.208 145 107.708 145C91.2078 145 58.7078 210.364 35.7078 202C12.7078 193.636 2.70781 182.5 8.70782 145C14.7078 107.5 35.7078 30 53.2078 18.5C70.7078 7 84.2078 7 95.2078 7C106.208 7 123.708 25 136.708 25H158.5" stroke="white" stroke-width="6" stroke-linecap="round"/>
-    <path d="M237.792 202C260.792 193.636 270.792 182.5 264.792 145C258.792 107.5 237.792 30.0001 220.292 18.5001" stroke="white" stroke-width="6" stroke-linecap="round"/>
-    <path d="M148.708 105H163.208" stroke="white" stroke-width="6"/>
+    <circle cx="192.708" cy="161" r="16" fill="#D1D7E0"/>
+    <path d="M80.7078 58V105H108.708" stroke="#D1D7E0" stroke-width="6"/>
+    <path d="M108.708 100L115.708 105L108.708 110V100Z" stroke="#D1D7E0" stroke-width="6"/>
+    <path d="M164.708 100L171.708 105L164.708 110V100Z" stroke="#D1D7E0" stroke-width="6"/>
+    <path d="M164.708 44L171.708 49L164.708 54V44Z" stroke="#D1D7E0" stroke-width="6"/>
+    <path d="M136.708 94V49H165.708" stroke="#D1D7E0" stroke-width="6"/>
+    <path d="M136.708 145C136.708 145 109.208 145 107.708 145C91.2078 145 58.7078 210.364 35.7078 202C12.7078 193.636 2.70781 182.5 8.70782 145C14.7078 107.5 35.7078 30 53.2078 18.5C70.7078 7 84.2078 7 95.2078 7C106.208 7 123.708 25 136.708 25H158.5" stroke="#D1D7E0" stroke-width="6" stroke-linecap="round"/>
+    <path d="M237.792 202C260.792 193.636 270.792 182.5 264.792 145C258.792 107.5 237.792 30.0001 220.292 18.5001" stroke="#D1D7E0" stroke-width="6" stroke-linecap="round"/>
+    <path d="M148.708 105H163.208" stroke="#D1D7E0" stroke-width="6"/>
   </g>
   <defs>
     <clipPath id="clip0_7_135">
-      <rect width="266" height="202" fill="white" transform="translate(4 4)"/>
+      <rect width="266" height="202" fill="#D1D7E0" transform="translate(4 4)"/>
     </clipPath>
     <clipPath id="clip1_7_135">
-      <rect width="32" height="32" fill="white" transform="translate(176.708 89)"/>
+      <rect width="32" height="32" fill="#D1D7E0" transform="translate(176.708 89)"/>
     </clipPath>
   </defs>
 </svg>

--- a/docs/assets/teleop_modular_logo_dark.svg
+++ b/docs/assets/teleop_modular_logo_dark.svg
@@ -1,0 +1,28 @@
+<svg width="274" height="210" viewBox="0 0 274 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="274" height="210"/>
+  <g clip-path="url(#clip0_7_135)">
+    <circle cx="80.7078" cy="49" r="16" fill="white"/>
+    <circle cx="136.708" cy="105" r="16" fill="white"/>
+    <circle cx="192.708" cy="49" r="16" fill="white"/>
+    <g clip-path="url(#clip1_7_135)">
+      <circle cx="192.708" cy="105" r="13" stroke="white" stroke-width="6"/>
+    </g>
+    <circle cx="192.708" cy="161" r="16" fill="white"/>
+    <path d="M80.7078 58V105H108.708" stroke="white" stroke-width="6"/>
+    <path d="M108.708 100L115.708 105L108.708 110V100Z" stroke="white" stroke-width="6"/>
+    <path d="M164.708 100L171.708 105L164.708 110V100Z" stroke="white" stroke-width="6"/>
+    <path d="M164.708 44L171.708 49L164.708 54V44Z" stroke="white" stroke-width="6"/>
+    <path d="M136.708 94V49H165.708" stroke="white" stroke-width="6"/>
+    <path d="M136.708 145C136.708 145 109.208 145 107.708 145C91.2078 145 58.7078 210.364 35.7078 202C12.7078 193.636 2.70781 182.5 8.70782 145C14.7078 107.5 35.7078 30 53.2078 18.5C70.7078 7 84.2078 7 95.2078 7C106.208 7 123.708 25 136.708 25H158.5" stroke="white" stroke-width="6" stroke-linecap="round"/>
+    <path d="M237.792 202C260.792 193.636 270.792 182.5 264.792 145C258.792 107.5 237.792 30.0001 220.292 18.5001" stroke="white" stroke-width="6" stroke-linecap="round"/>
+    <path d="M148.708 105H163.208" stroke="white" stroke-width="6"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_7_135">
+      <rect width="266" height="202" fill="white" transform="translate(4 4)"/>
+    </clipPath>
+    <clipPath id="clip1_7_135">
+      <rect width="32" height="32" fill="white" transform="translate(176.708 89)"/>
+    </clipPath>
+  </defs>
+</svg>


### PR DESCRIPTION
I created a logo for teleop_modular, with two variants: 

<table align="center">
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/f42713ac-471d-4475-bc46-3c1e2b4f4a13" alt="Normal Logo">
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/e0d31583-a29d-4f8b-a10c-c59e9a07cb53" alt="Dark Mode Logo">
    </td>
  </tr>
</table>

I added the logo to the top level README.md, where it will automatically switch between the two variants based on the github color scheme being used.

This should match your current color scheme:

<p align="center">
  <picture>
    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/f42713ac-471d-4475-bc46-3c1e2b4f4a13">
    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/e0d31583-a29d-4f8b-a10c-c59e9a07cb53">
    <img src="https://github.com/user-attachments/assets/f42713ac-471d-4475-bc46-3c1e2b4f4a13" alt="teleop_modular logo">
  </picture>
</p>


Some decisions behind design elements:
- The silhouette resembles a controller, implying the packages use case
- The dots represent, from left to right, an input source, the input manager, and control modes. 
  - The leftmost dot is also the left joystick for the controller silhouette
- The arrows represent the communication across abstraction layers.
- The break in the controller silhouette is to imply the modularity of the system
- The dot with a white center is meant to represent an 'active' control mode
  - since it is in the same spot as where the right joystick should be on the controller, I wanted it to stand out
- These make reference to the ROS2 ecosystem, particularly ros2_control, while trying to main a very distinct style as to avoid confusion in affiliation. 
<table align="center">
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/f42713ac-471d-4475-bc46-3c1e2b4f4a13" width="100px" alt="Normal Logo">
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/16c9747c-5a1b-49a7-9b84-26644863fe0e" width="65px" alt="Dark Mode Logo">
    </td>
  </tr>
</table>
Please let me know your thoughts!