### PR TITLE
Overhaul teleop_modular_twist/TwistControlMode

### DIFF
--- a/teleop_core/README.md
+++ b/teleop_core/README.md
@@ -76,7 +76,7 @@ joy_input_source:
           # Clamp input value to a range
           range:                
             in: [-1, 1]
-            limit: true  
+            limits: true  
         speed:
           from: "right_trigger"
           # Remap the range of the input from [-1, 1] to [0, 1].

--- a/teleop_modular_twist/README.md
+++ b/teleop_modular_twist/README.md
@@ -13,13 +13,13 @@ This is a feature-rich ControlMode that sends [Twist](https://docs.ros2.org/late
 - `angular.z`: The z component of the angular velocity
 
 
-- `speed`: The input axis that scales the output speed from 0 to 1. *(Required unless the `use_speed_input` param is set to false)*
+- `speed`: The input axis that scales the output speed from 0 to 1. *(Required if `use_speed_input` is set to true)*
 
-> **Note**: `linear.*` and `angular.*` inputs are multiplied by the `speed` input and the `scale.linear.*` / 
-> `scale.angular.*` parameters in the output twist message. 
+> **Note**: `linear.*` and `angular.*` inputs are multiplied by the `speed` input (when `use_speed_input` is set to 
+> true) and the `scale.linear.*` / `scale.angular.*` parameters in the output twist message. 
 > 
 > If you don't want to use an additional `speed` input, you can disable it by setting `use_speed_input` to false in 
-> your parameter file. It is enabled by default.
+> your parameter file. It is disabled by default.
  
 > **Note**: `linear.*` and `angular.*` are usually values between -1 and 1 that you then turn into a velocity unit by 
 > setting `scale.linear.*` and `scale.angular.*` parameters to be your largest desired speed. 
@@ -77,7 +77,7 @@ twist_control_mode:
 
     # Prevent velocities larger than the specified values from being emitted
     # If you leave a parameter unspecified, no limit will be applied. (Optional)
-    limit: 
+    limits: 
       linear:
         x: 1.0
         y: 1.0
@@ -86,12 +86,12 @@ twist_control_mode:
         # set values for each component. If not set, any unspecified x,y,z will not 
         # be limited.
         all: 1.0
-        # True by default. When true, the magnitude of the velocity will be 
+        # False by default. When true, the magnitude of the velocity will be 
         # limited rather than individual axes. Limiting will still be done  
         # proportionally to the provided x,y,z limits, which don't have to be
         # uniform.
         normalized: true
-        # True by default. When true, limits are scaled with the 'speed' input.
+        # False by default. When true, limits are scaled with the 'speed' input.
         scale_with_speed: true
       angular:
         x: 1.0
@@ -101,12 +101,12 @@ twist_control_mode:
         # set values for each component. If not set, any unspecified x,y,z will not 
         # be limited.
         all: 1.0
-        # True by default. When true, the magnitude of the velocity will be 
+        # False by default. When true, the magnitude of the velocity will be 
         # limited rather than individual axes. Limiting will still be done  
         # proportionally to the provided x,y,z limits, which don't have to be
         # uniform.
         normalized: true
-        # True by default. When true, limits are scaled with the 'speed' input.
+        # False by default. When true, limits are scaled with the 'speed' input.
         scale_with_speed: true
       
 ```

--- a/teleop_modular_twist/README.md
+++ b/teleop_modular_twist/README.md
@@ -76,7 +76,7 @@ twist_control_mode:
         all: 1.0
 
     # Prevent velocities larger than the specified values from being emitted
-    # If you leave a parameter unspecified, no limit will be applied. (Optional)
+    # If you leave a parameter unspecified, no limits will be applied. (Optional)
     limits: 
       linear:
         x: 1.0

--- a/teleop_modular_twist/README.md
+++ b/teleop_modular_twist/README.md
@@ -35,12 +35,15 @@ teleop_node:
 twist_control_mode:
   ros__parameters:
 
-    # Topic to send Twist messages to. (Required)
+    # Topic to send Twist messages to. (Optional if stamped_topic is set)
     topic: "/turtle1/cmd_vel"
+
+    # Topic to send TwistStamped messages to. (Optional if stamped_topic is set) 
+    stamped_topic: "/cmd_vel_stamped"
 
     # Used as the header.frame_id of all sent TwistStamped messages. 
     # The name of the reference frame twist messages are relative to. (Optional)
-    frame_id: "endeffector"
+    frame: "endeffector"
 
     max_speed:
       # The maximum value for the linear component of the twist messages, in metres per second. 

--- a/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
+++ b/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
@@ -22,7 +22,7 @@ namespace teleop_modular_twist
 {
 using namespace control_mode;
 
-class TwistControlMode : public ControlMode
+class TELEOP_MODULAR_TWIST_PUBLIC TwistControlMode : public ControlMode
 {
 public:
   TwistControlMode();

--- a/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
+++ b/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
@@ -13,6 +13,7 @@
 #include <rclcpp/time.hpp>
 #include "teleop_modular_twist/visibility_control.h"
 #include "control_mode/control_mode.hpp"
+#include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "twist_control_mode_parameters.hpp"
 
@@ -62,7 +63,8 @@ private:
   Axis::SharedPtr pitch_;
   Axis::SharedPtr roll_;
 
-  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr stamped_publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_;
 };
 
 }  // namespace teleop_modular_twist

--- a/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
+++ b/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
@@ -66,7 +66,7 @@ private:
     /// When true, limits will be applied to the axis inputs relative to the 'speed' input.
     bool scale_limits_with_speed = true;
 
-    void set_limits(const NumberVector3 values, double all, bool normalized);
+    void set_limits(NumberVector3 values, double all, bool normalized);
     /**
      * \brief Calculates the value for a Vector3 message based on the input axis values, and given speed_coefficient.
      *

--- a/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
+++ b/teleop_modular_twist/include/teleop_modular_twist/teleop_modular_twist.hpp
@@ -59,20 +59,31 @@ private:
     /// A scale to multiply axis values by when populating vector3 messages
     NumberVector3 scale = {1.0, 1.0, 1.0};
     /// limits to apply to the vector3 message
-    std::optional<NumberVector3> limit = std::nullopt;
+    std::optional<NumberVector3> limits = std::nullopt;
 
     /// Switches limiting logic from simple component-wise limiting to more complex normalization based limits.
     bool normalized_limits = true;
     /// When true, limits will be applied to the axis inputs relative to the 'speed' input.
     bool scale_limits_with_speed = true;
 
-    void set_limits(NumberVector3 values, double all, bool normalized);
+    /**
+     * \brief Given the parameter values, converts them to usable limits for apply_to().
+     *
+     * Any negative parameter values will translate to an infinity -- which is effectively no limit.
+     * If all limits end up being infinity, limits will become std::nullopt.
+     *
+     * \param values[in]    The x,y,z limit parameters all put into an array<double, 3>
+     * \param all[in]       The 'all' default limit parameter to use for any unspecified x,y,z in values
+     */
+    void set_limits(NumberVector3 values, double all);
+
     /**
      * \brief Calculates the value for a Vector3 message based on the input axis values, and given speed_coefficient.
      *
      * This method applies limits when limit.has_value().
+     *
      * \param msg[out]  The message to put calculated values in
-     * \param speed_coefficient[out]    The value to multiply all speeds by
+     * \param speed_coefficient[in]     The value to multiply all speeds by
      */
     void apply_to(geometry_msgs::msg::Vector3 & msg, double speed_coefficient);
   };

--- a/teleop_modular_twist/src/teleop_modular_twist.cpp
+++ b/teleop_modular_twist/src/teleop_modular_twist.cpp
@@ -134,7 +134,7 @@ return_type TwistControlMode::update(const rclcpp::Time & now, const rclcpp::Dur
     return return_type::OK;
   }
 
-  const float speed_coefficient = std::max(speed_->value(), 0.0f);
+  const float speed_coefficient = params_.use_speed_input ? std::max(speed_->value(), 0.0f) : 1.0;
   auto twist = geometry_msgs::msg::Twist();
 
   linear_.apply_to(twist.linear, speed_coefficient);

--- a/teleop_modular_twist/src/teleop_modular_twist.cpp
+++ b/teleop_modular_twist/src/teleop_modular_twist.cpp
@@ -48,23 +48,14 @@ CallbackReturn TwistControlMode::on_configure(const State &)
     linear_.scale_limits_with_speed = params_.limit.angular.scale_with_speed;
   }
 
-  // Create publishers
-  const rclcpp::QoS qos_profile =
-    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_sensor_data))
-    .best_effort()
-    .transient_local()
-    .keep_last(1);
-
   if (!params_.stamped_topic.empty()) {
     stamped_publisher_ =
       get_node()->create_publisher<geometry_msgs::msg::TwistStamped>(
-      params_.stamped_topic,
-      qos_profile);
+      params_.stamped_topic, params_.qos);
   }
   if (!params_.topic.empty()) {
     publisher_ = get_node()->create_publisher<geometry_msgs::msg::Twist>(
-      params_.topic,
-      qos_profile);
+      params_.topic, params_.qos);
   }
 
   // You've probably made a mistake if you aren't publishing anything

--- a/teleop_modular_twist/src/teleop_modular_twist.cpp
+++ b/teleop_modular_twist/src/teleop_modular_twist.cpp
@@ -46,6 +46,18 @@ CallbackReturn TwistControlMode::on_configure(const State &)
       {params_.limit.angular.x, params_.limit.angular.y, params_.limit.angular.z},
       params_.limit.angular.all, params_.limit.angular.normalized);
     linear_.scale_limits_with_speed = params_.limit.angular.scale_with_speed;
+
+    linear_.scale = {
+      params_.scale.linear.x * params_.scale.linear.all,
+      params_.scale.linear.y * params_.scale.linear.all,
+      params_.scale.linear.z * params_.scale.linear.all,
+    };
+
+    angular_.scale = {
+      params_.scale.angular.x * params_.scale.angular.all,
+      params_.scale.angular.y * params_.scale.angular.all,
+      params_.scale.angular.z * params_.scale.angular.all,
+    };
   }
 
   if (!params_.stamped_topic.empty()) {

--- a/teleop_modular_twist/src/teleop_modular_twist.cpp
+++ b/teleop_modular_twist/src/teleop_modular_twist.cpp
@@ -38,14 +38,14 @@ CallbackReturn TwistControlMode::on_configure(const State &)
 
     // Set up handle configurations for linear and angular inputs
     linear_.set_limits(
-      {params_.limit.linear.x, params_.limit.linear.y, params_.limit.linear.z},
-      params_.limit.linear.all, params_.limit.linear.normalized);
-    linear_.scale_limits_with_speed = params_.limit.linear.scale_with_speed;
+      {params_.limits.linear.x, params_.limits.linear.y, params_.limits.linear.z},
+      params_.limits.linear.all, params_.limits.linear.normalized);
+    linear_.scale_limits_with_speed = params_.limits.linear.scale_with_speed;
 
     angular_.set_limits(
-      {params_.limit.angular.x, params_.limit.angular.y, params_.limit.angular.z},
-      params_.limit.angular.all, params_.limit.angular.normalized);
-    linear_.scale_limits_with_speed = params_.limit.angular.scale_with_speed;
+      {params_.limits.angular.x, params_.limits.angular.y, params_.limits.angular.z},
+      params_.limits.angular.all, params_.limits.angular.normalized);
+    linear_.scale_limits_with_speed = params_.limits.angular.scale_with_speed;
 
     linear_.scale = {
       params_.scale.linear.x * params_.scale.linear.all,
@@ -137,7 +137,7 @@ return_type TwistControlMode::update(const rclcpp::Time & now, const rclcpp::Dur
     return return_type::OK;
   }
 
-  const float speed_coefficient = params_.use_speed_input ? std::max(speed_->value(), 0.0f) : 1.0;
+  const float speed_coefficient = params_.use_speed_input ? std::max(speed_->value(), 0.0f) : 1.0f;
   auto twist = geometry_msgs::msg::Twist();
 
   linear_.apply_to(twist.linear, speed_coefficient);

--- a/teleop_modular_twist/src/twist_control_mode_parameters.yaml
+++ b/teleop_modular_twist/src/twist_control_mode_parameters.yaml
@@ -17,7 +17,7 @@ teleop_modular_twist:
   use_speed_input:
     type: bool
     default_value: false
-    description: "When true, all speeds will be multiplied by the axis named 'speed'."
+    description: "When true, all speeds will be multiplied by the axis named 'speed'. Otherwise, they will not."
 
   scale:
     linear:

--- a/teleop_modular_twist/src/twist_control_mode_parameters.yaml
+++ b/teleop_modular_twist/src/twist_control_mode_parameters.yaml
@@ -14,63 +14,105 @@ teleop_modular_twist:
     default_value: ""
     description: "The name of the reference frame twist messages are relative to. Included as the header.frame_id of all 
     sent TwistStamped messages."
+  use_speed_input:
+    type: bool
+    default_value: false
+    description: "When true, all speeds will be multiplied by the axis named 'speed'."
 
   scale:
     linear:
       x:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply the linear y axis input by."
+        description: "The speed to multiply the linear x axis input by (in metres per second)."
       y:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply the linear y axis input by."
+        description: "The speed to multiply the linear y axis input by (in metres per second)."
       z:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply the linear y axis input by."
+        description: "The speed to multiply the linear z axis input by (in metres per second)."
       all:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply ALL linear axis inputs by. This is applied ontop of 
+        description: "The speed to multiply ALL linear axis inputs by (in metres per second). This is applied ontop of 
         scale.linear.* for individual axes."
     angular:
       x:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply the angular x axis input by."
+        description: "The speed to multiply the linear x axis input by (in radians per second)."
       y:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply the angular y axis input by."
+        description: "The speed to multiply the linear y axis input by (in radians per second)."
       z:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply the angular z axis input by."
+        description: "The speed to multiply the linear z axis input by (in radians per second)."
       all:
         type: double
         default_value: 1.0
-        description: "The speed (in metres per second) to multiply ALL linear axis inputs by. This is applied ontop of 
+        description: "The speed to multiply ALL angular axis inputs by (in radians per second). This is applied ontop of 
         scale.linear.* for individual axes."
 
 
-
-  max_speed:
+  limit:
     linear:
-      type: double
-      default_value: 0.0
-      description: "The maximum value for the linear component of the twist messages, in metres per second. An axis input 
-      of 1 and 'speed' of 1 will correspond to this value being sent."
+      x:
+        type: double
+        default_value: -1.0
+        description: "The max linear x velocity magnitude (in metres per second). Must be non-negative."
+      y:
+        type: double
+        default_value: -1.0
+        description: "The max linear y velocity magnitude (in metres per second). Must be non-negative."
+      z:
+        type: double
+        default_value: -1.0
+        description: "The max linear z velocity magnitude (in metres per second). Must be non-negative."
+      all:
+        type: double
+        default_value: -1.0
+        description: "The speed to limit ALL linear axis inputs below (in metres per second). Must be non-negative."
+      normalized:
+        type: bool
+        default_value: true
+        description: "When true, the magnitude of the linear velocity will be limited, rather than individual axes. 
+        If different axes have different limits, the limits will be elliptical."
+      scale_with_speed:
+        type: bool
+        default_value: true
+        description: "When true, limits will scale with the 'speed' input. Useful for keeping normalized behaviour at 
+        different values of speed."
     angular:
-      type: double
-      default_value: 0.0
-      description: "The maximum value for the angular component of the twist messages, in radians per second. An axis 
-      input of 1 and 'speed' of 1 will correspond to this value being sent."
-    normalized:
-      type: bool
-      default_value: true
-      description: "When true, the magnitude of the velocity will be limited to be less than or equal to the max speed, 
-      rather than individual axes."
+      x:
+        type: double
+        default_value: -1.0
+        description: "The max angular x velocity magnitude (in metres per second). Must be non-negative."
+      y:
+        type: double
+        default_value: -1.0
+        description: "The max angular y velocity magnitude (in metres per second). Must be non-negative."
+      z:
+        type: double
+        default_value: -1.0
+        description: "The max angular z velocity magnitude (in metres per second). Must be non-negative."
+      all:
+        type: double
+        default_value: -1.0
+        description: "The speed to limit ALL angular axis inputs below (in metres per second). Must be non-negative."
+      normalized:
+        type: bool
+        default_value: true
+        description: "When true, the magnitude of the angular velocity will be limited, rather than individual axes. 
+        If different axes have different limits, the limits will be elliptical."
+      scale_with_speed:
+        type: bool
+        default_value: true
+        description: "When true, limits will scale with the 'speed' input. Useful for keeping normalized behaviour at 
+        different values of speed."
 
   # Input name configuration
   input_names:
@@ -82,29 +124,29 @@ teleop_modular_twist:
       type: string
       default_value: "speed"
       description: "The name of the axis input that scales the output speed from 0 to 1."
-    twist_x:
-      type: string
-      default_value: "twist_x"
-      description: "The input axis providing the x component of the twist linear velocity."
-    twist_y:
-      type: string
-      default_value: "twist_y"
-      description: "The input axis providing the y component of the twist linear velocity."
-    twist_z:
-      type: string
-      default_value: "twist_z"
-      description: "The input axis providing the z component of the twist linear velocity."
-    twist_roll:
-      type: string
-      default_value: "twist_roll"
-      description: "The input axis providing the x component of the twist angular velocity."
-    twist_pitch:
-      type: string
-      default_value: "twist_pitch"
-      description: "The input axis providing the y component of the twist angular velocity."
-    twist_yaw:
-      type: string
-      default_value: "twist_yaw"
-      description: "The input axis providing the z component of the twist angular velocity."
-
-
+    linear:
+      x:
+        type: string
+        default_value: "linear.x"
+        description: "The input axis providing the x component of the twist linear velocity."
+      y:
+        type: string
+        default_value: "linear.y"
+        description: "The input axis providing the y component of the twist linear velocity."
+      z:
+        type: string
+        default_value: "linear.z"
+        description: "The input axis providing the z component of the twist linear velocity."
+    angular:
+      x:
+        type: string
+        default_value: "angular.x"
+        description: "The input axis providing the x component of the twist angular velocity."
+      y:
+        type: string
+        default_value: "angular.y"
+        description: "The input axis providing the y component of the twist angular velocity."
+      z:
+        type: string
+        default_value: "angular.z"
+        description: "The input axis providing the z component of the twist angular velocity."

--- a/teleop_modular_twist/src/twist_control_mode_parameters.yaml
+++ b/teleop_modular_twist/src/twist_control_mode_parameters.yaml
@@ -18,6 +18,7 @@ teleop_modular_twist:
     default_value: ""
     description: "The name of the reference frame twist messages are relative to. Included as the header.frame_id of all 
     sent TwistStamped messages."
+
   use_speed_input:
     type: bool
     default_value: false
@@ -61,8 +62,7 @@ teleop_modular_twist:
         description: "The speed to multiply ALL angular axis inputs by (in radians per second). This is applied ontop of 
         scale.linear.* for individual axes."
 
-
-  limit:
+  limits:
     linear:
       x:
         type: double
@@ -82,12 +82,12 @@ teleop_modular_twist:
         description: "The speed to limit ALL linear axis inputs below (in metres per second). Must be non-negative."
       normalized:
         type: bool
-        default_value: true
+        default_value: false
         description: "When true, the magnitude of the linear velocity will be limited, rather than individual axes. 
         If different axes have different limits, the limits will be elliptical."
       scale_with_speed:
         type: bool
-        default_value: true
+        default_value: false
         description: "When true, limits will scale with the 'speed' input. Useful for keeping normalized behaviour at 
         different values of speed."
     angular:
@@ -109,12 +109,12 @@ teleop_modular_twist:
         description: "The speed to limit ALL angular axis inputs below (in metres per second). Must be non-negative."
       normalized:
         type: bool
-        default_value: true
+        default_value: false
         description: "When true, the magnitude of the angular velocity will be limited, rather than individual axes. 
         If different axes have different limits, the limits will be elliptical."
       scale_with_speed:
         type: bool
-        default_value: true
+        default_value: false
         description: "When true, limits will scale with the 'speed' input. Useful for keeping normalized behaviour at 
         different values of speed."
 

--- a/teleop_modular_twist/src/twist_control_mode_parameters.yaml
+++ b/teleop_modular_twist/src/twist_control_mode_parameters.yaml
@@ -4,11 +4,56 @@ teleop_modular_twist:
   topic:
     type: string
     default_value: ""
-    description: "The topic to publish TwistStamped messages to."
-  frame_id:
+    description: "The topic to publish Twist messages to."
+  stamped_topic:
     type: string
     default_value: ""
-    description: "The name of the reference frame twist messages are relative to. Included as the header.frame_id of all sent TwistStamped messages."
+    description: "The topic to publish TwistStamped messages to."
+  frame:
+    type: string
+    default_value: ""
+    description: "The name of the reference frame twist messages are relative to. Included as the header.frame_id of all 
+    sent TwistStamped messages."
+
+  scale:
+    linear:
+      x:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply the linear y axis input by."
+      y:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply the linear y axis input by."
+      z:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply the linear y axis input by."
+      all:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply ALL linear axis inputs by. This is applied ontop of 
+        scale.linear.* for individual axes."
+    angular:
+      x:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply the angular x axis input by."
+      y:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply the angular y axis input by."
+      z:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply the angular z axis input by."
+      all:
+        type: double
+        default_value: 1.0
+        description: "The speed (in metres per second) to multiply ALL linear axis inputs by. This is applied ontop of 
+        scale.linear.* for individual axes."
+
+
 
   max_speed:
     linear:

--- a/teleop_modular_twist/src/twist_control_mode_parameters.yaml
+++ b/teleop_modular_twist/src/twist_control_mode_parameters.yaml
@@ -9,6 +9,10 @@ teleop_modular_twist:
     type: string
     default_value: ""
     description: "The topic to publish TwistStamped messages to."
+  qos:
+    type: int
+    default_value: 10
+    description: "The QoS value to use when creating publishers."
   frame:
     type: string
     default_value: ""


### PR DESCRIPTION
This is an overhaul of the TwistControlMode, to make it useful for more use cases. 
- Added limits
- Refactored code to be much cleaner
- Changed input axis naming convention to use `.`s
- Made QoS configurable
- Added support for unstamped Twist messages

I can now confidently say this is the most feature-rich generalized teleop implementation for twist robots

I now need to update the guides to reflect the changes I made.