### PR TITLE
Allow node name to be specified

### DIFF
--- a/teleop_node/src/teleop_node.cpp
+++ b/teleop_node/src/teleop_node.cpp
@@ -201,7 +201,20 @@ TeleopNode::~TeleopNode()
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  const auto node = std::make_shared<rclcpp::Node>("teleop_node");
+
+  std::string node_name = "teleop_node";
+
+  // Manual CLI parsing to get --node-name
+  for (int i = 1; i < argc; ++i)
+  {
+    if (std::string(argv[i]) == "--node-name" && i + 1 < argc)
+    {
+      node_name = argv[i + 1];
+      ++i;  // Skip next argv as it's consumed
+    }
+  }
+
+  const auto node = std::make_shared<rclcpp::Node>(node_name);
   const auto teleop_modular = std::make_shared<teleop::TeleopNode>(node);
   const auto executor = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   executor->add_node(node);


### PR DESCRIPTION
This PR allows the teleop_node name to be specified using a command line argument `--node-name`

<img width="1401" height="246" alt="image" src="https://github.com/user-attachments/assets/2143d3a5-b5de-4fcf-958f-5469e52a256f" />

This should allow for multiple teleop systems to coexist simultaneously.