### PR TITLE
Set Axis commands

### DIFF
--- a/control_mode/include/control_mode/control_mode.hpp
+++ b/control_mode/include/control_mode/control_mode.hpp
@@ -105,17 +105,18 @@ public:
   }
 
   /**
-   * \brief Gets if the control mode should be locked, checking if the "locked" input button is true. When true, the 
+   * \brief Gets if the control mode should be locked, checking if the "locked" input button is true. When true, the
    * control mode is expected to tell the control system to do nothing.
-   * 
+   *
    * \returns True when the "locked" input is true
    */
-  [[nodiscard]] bool is_locked() {
+  [[nodiscard]] bool is_locked()
+  {
     return locked_->value();
   }
 
   /**
-   * \brief Called after the control_mode is created, allowing the control_mode to set up any structures that need to 
+   * \brief Called after the control_mode is created, allowing the control_mode to set up any structures that need to
    * exist for the entire lifecycle of the control_mode.
    */
   virtual return_type on_init()
@@ -125,28 +126,28 @@ public:
 
   /**
    * \brief Called after on_init, allows the node to get any configuration from node parameters or otherwise.
-   * 
+   *
    * If the configuration cannot be successfully achieved it will transition to ErrorProcessing calling on_error().
-   * 
+   *
    * \param previous_state The previous lifecycle state being transitioned from.
    */
   CallbackReturn on_configure(const State &) override
   {
     return CallbackReturn::SUCCESS;
   }
-  
+
   /**
-   * \brief Exposes inputs to the control mode so that it can capture shared pointers to any inputs it needs. Called 
+   * \brief Exposes inputs to the control mode so that it can capture shared pointers to any inputs it needs. Called
    * after configure.
-   * 
+   *
    * \param inputs References to the collection of buttons and axes to be used by the control_mode.
    */
   void capture_inputs(Inputs inputs);
 
   /**
-   * \brief Called after on_configure, allows the implementer to capture shared pointers to any inputs needed by the 
+   * \brief Called after on_configure, allows the implementer to capture shared pointers to any inputs needed by the
    * control mode.
-   * 
+   *
    * \param inputs References to the collection of buttons and axes to be used by the control_mode.
    */
   virtual void on_capture_inputs(Inputs inputs) = 0;
@@ -154,32 +155,32 @@ public:
   /**
    * \brief Called when there are new inputs available. The implementer should send a message to the control system
    * based on input values.
-   * 
+   *
    * \param now   The theoretical current time, based on the time the inputs were received.
    * \param period    The difference in time since the last update.
    */
   virtual return_type on_update(const rclcpp::Time & now, const rclcpp::Duration & period) = 0;
-  
+
   /**
-   * \brief This method is expected to do any final preparations to start executing. This may include acquiring 
-   * resources that are only held while the node is actually active, such as access to hardware. Ideally, no preparation 
+   * \brief This method is expected to do any final preparations to start executing. This may include acquiring
+   * resources that are only held while the node is actually active, such as access to hardware. Ideally, no preparation
    * that requires significant time (such as lengthy hardware initialisation) should be performed in this callback.
-   * 
+   *
    * If this cannot be successfully achieved it will transition to ErrorProcessing calling on_error().
-   * 
+   *
    * \param previous_state The previous lifecycle state being transitioned from.
    */
   CallbackReturn on_activate(const State &) override
   {
     return CallbackReturn::SUCCESS;
   }
-  
+
   /**
-   * \brief This method is expected to clear all state and return the node to a functionally equivalent state as when 
+   * \brief This method is expected to clear all state and return the node to a functionally equivalent state as when
    * first created. You may also wish to tell dependent control systems to halt as part of this method.
-   * 
+   *
    * If the deactivating cannot be successfully achieved it will transition to ErrorProcessing calling on_error().
-   * 
+   *
    * \param previous_state The previous lifecycle state being transitioned from.
    */
   CallbackReturn on_deactivate(const State &) override
@@ -188,11 +189,11 @@ public:
   }
 
   /**
-   * \brief This method is expected to clear all state and return the node to a functionally equivalent state as when 
-   * first created. 
-   * 
+   * \brief This method is expected to clear all state and return the node to a functionally equivalent state as when
+   * first created.
+   *
    * If the cleanup cannot be successfully achieved it will transition to ErrorProcessing calling on_error().
-   * 
+   *
    * \param previous_state The previous lifecycle state being transitioned from.
    */
   CallbackReturn on_cleanup(const State &) override
@@ -201,14 +202,14 @@ public:
   }
 
   /**
-   * \brief This transition state is where any error can be cleaned up. It is possible to enter this state from any 
-   * state where user code will be executed. If error handling is successfully completed the node can return to 
-   * Unconfigured, If a full cleanup is not possible it must fail and the node will transition to Finalized in 
+   * \brief This transition state is where any error can be cleaned up. It is possible to enter this state from any
+   * state where user code will be executed. If error handling is successfully completed the node can return to
+   * Unconfigured, If a full cleanup is not possible it must fail and the node will transition to Finalized in
    * preparation for destruction.
-   * 
-   * Transitions to ErrorProcessing may be caused by error return codes in callbacks as well as methods within a 
+   *
+   * Transitions to ErrorProcessing may be caused by error return codes in callbacks as well as methods within a
    * callback or an uncaught exception.
-   * 
+   *
    * \param previous_state The previous lifecycle state being transitioned from.
    */
   CallbackReturn on_error(const State &) override
@@ -218,7 +219,7 @@ public:
 
   /**
    * \brief This method is expected to do any cleanup necessary before destruction.
-   * 
+   *
    * \param previous_state The previous lifecycle state being transitioned from.
    */
   CallbackReturn on_shutdown(const State &) override
@@ -231,12 +232,12 @@ public:
 
   /// Gets the names of all ros2_control controllers to activate alongside this control mode.
   [[nodiscard]] const std::vector<std::string> & get_controllers() const;
-  
+
 protected:
-  /// An input button to represent a lock for the control mode. The control mode should tell the control system to halt 
+  /// An input button to represent a lock for the control mode. The control mode should tell the control system to halt
   /// when ->value() is true
   Button::SharedPtr locked_;
-  
+
 private:
   /// The ROS2 node created by teleop_modular, which we get params from (for base and child classes)
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;

--- a/control_mode/src/control_mode.cpp
+++ b/control_mode/src/control_mode.cpp
@@ -74,7 +74,8 @@ return_type ControlMode::init(
   return return_type::OK;
 }
 
-void ControlMode::capture_inputs(Inputs inputs) {
+void ControlMode::capture_inputs(Inputs inputs)
+{
   locked_ = inputs.buttons["locked"];
   on_capture_inputs(inputs);
 }

--- a/teleop_core/CMakeLists.txt
+++ b/teleop_core/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(${PROJECT_NAME} SHARED
   src/input_sources/InputSourceManager.cpp
   src/commands/CommandManager.cpp
   src/commands/SetAxisCommand.cpp
+  src/commands/IncrementAxisCommand.cpp
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)  # Require C++17

--- a/teleop_core/CMakeLists.txt
+++ b/teleop_core/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(${PROJECT_NAME} SHARED
 
   src/input_sources/InputSourceManager.cpp
   src/commands/CommandManager.cpp
+  src/commands/SetAxisCommand.cpp
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)  # Require C++17

--- a/teleop_core/include/teleop_core/commands/CommandDelegate.hpp
+++ b/teleop_core/include/teleop_core/commands/CommandDelegate.hpp
@@ -39,7 +39,7 @@ public:
   virtual ~CommandDelegate() = default;
 
   [[nodiscard]] virtual std::shared_ptr<rclcpp::Node> get_node() const = 0;
-  [[nodiscard]] virtual const InputManager & get_inputs() const = 0;
+  [[nodiscard]] virtual InputManager & get_inputs() = 0;
   [[nodiscard]] virtual state::StateManager & get_states() = 0;
   [[nodiscard]] virtual const std::shared_ptr<internal::ControlModeManager> get_control_modes()
   const = 0;

--- a/teleop_core/include/teleop_core/commands/IncrementAxisCommand.hpp
+++ b/teleop_core/include/teleop_core/commands/IncrementAxisCommand.hpp
@@ -35,6 +35,7 @@ protected:
     std::string name;
     float by = 0.0;
     float until = 1.0;
+    bool log = true;
   };
 
   Params params_{};

--- a/teleop_core/include/teleop_core/commands/IncrementAxisCommand.hpp
+++ b/teleop_core/include/teleop_core/commands/IncrementAxisCommand.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Bailey Chessum
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Created by Bailey Chessum on 31/7/25.
+//
+
+#ifndef TELEOP_CORE_INCREMENTAXISCOMMAND_HPP
+#define TELEOP_CORE_INCREMENTAXISCOMMAND_HPP
+
+#include "teleop_core/commands/Command.hpp"
+
+namespace teleop
+{
+
+class IncrementAxisCommand : public Command
+{
+
+public:
+  IncrementAxisCommand() = default;
+  void on_initialize(
+      const std::string & prefix,
+      const ParameterInterface::SharedPtr & parameters) override;
+
+  void execute(CommandDelegate & context, const rclcpp::Time & now) override;
+
+protected:
+  struct Params
+  {
+    std::string name;
+    float by = 0.0;
+    float until = 1.0;
+  };
+
+  Params params_{};
+};
+
+}  // namespace teleop
+
+#endif  // TELEOP_CORE_INCREMENTAXISCOMMAND_HPP

--- a/teleop_core/include/teleop_core/commands/IncrementAxisCommand.hpp
+++ b/teleop_core/include/teleop_core/commands/IncrementAxisCommand.hpp
@@ -24,8 +24,8 @@ class IncrementAxisCommand : public Command
 public:
   IncrementAxisCommand() = default;
   void on_initialize(
-      const std::string & prefix,
-      const ParameterInterface::SharedPtr & parameters) override;
+    const std::string & prefix,
+    const ParameterInterface::SharedPtr & parameters) override;
 
   void execute(CommandDelegate & context, const rclcpp::Time & now) override;
 

--- a/teleop_core/include/teleop_core/commands/SetAxisCommand.hpp
+++ b/teleop_core/include/teleop_core/commands/SetAxisCommand.hpp
@@ -23,8 +23,8 @@ class SetAxisCommand : public Command
 public:
   SetAxisCommand() = default;
   void on_initialize(
-      const std::string & prefix,
-      const ParameterInterface::SharedPtr & parameters) override;
+    const std::string & prefix,
+    const ParameterInterface::SharedPtr & parameters) override;
 
   void execute(CommandDelegate & context, const rclcpp::Time & now) override;
 

--- a/teleop_core/include/teleop_core/commands/SetAxisCommand.hpp
+++ b/teleop_core/include/teleop_core/commands/SetAxisCommand.hpp
@@ -1,0 +1,43 @@
+// Copyright 2025 Bailey Chessum
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Created by Bailey Chessum on 31/7/25.
+//
+
+#ifndef TELEOP_CORE_SETAXISCOMMAND_HPP
+#define TELEOP_CORE_SETAXISCOMMAND_HPP
+
+#include "teleop_core/commands/Command.hpp"
+
+namespace teleop
+{
+
+class SetAxisCommand : public Command
+{
+public:
+  SetAxisCommand() = default;
+  void on_initialize(
+      const std::string & prefix,
+      const ParameterInterface::SharedPtr & parameters) override;
+
+  void execute(CommandDelegate & context, const rclcpp::Time & now) override;
+
+protected:
+  struct Params
+  {
+    std::string name;
+    float value = 0.0;
+  };
+
+  Params params_{};
+};
+
+}  // namespace teleop
+
+#endif  // TELEOP_CORE_SETAXISCOMMAND_HPP

--- a/teleop_core/include/teleop_core/inputs/InputManager.hpp
+++ b/teleop_core/include/teleop_core/inputs/InputManager.hpp
@@ -66,6 +66,15 @@ public:
     return axes_;
   }
 
+  [[nodiscard]] const InputCollection<Button> & get_buttons() const
+  {
+    return buttons_;
+  }
+  [[nodiscard]] const InputCollection<Axis> & get_axes() const
+  {
+    return axes_;
+  }
+
   /**
    * @brief polls the current input state and propagates changes:
    *   - Debounces buttons and axes

--- a/teleop_core/src/commands/IncrementAxisCommand.cpp
+++ b/teleop_core/src/commands/IncrementAxisCommand.cpp
@@ -1,0 +1,86 @@
+// Copyright 2025 Bailey Chessum
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Created by Bailey Chessum on 31/7/25.
+//
+
+#include "teleop_core/commands/IncrementAxisCommand.hpp"
+
+namespace teleop
+{
+
+void IncrementAxisCommand::on_initialize(const std::string& prefix,
+                                         const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& parameters)
+{
+  Params params{};
+
+  auto name_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
+  name_descriptor.name = prefix + "name";
+  name_descriptor.description = "The name of the axis to increment the value of.";
+  parameters->declare_parameter(name_descriptor.name, rclcpp::ParameterValue(""), name_descriptor);
+  if (rclcpp::Parameter name_param; parameters->get_parameter(name_descriptor.name, name_param)) {
+    params.name = name_param.as_string();
+  }
+
+  // The parameters have funny names to keep different command types distinguishable by their parameter names
+  auto by_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
+  by_descriptor.name = prefix + "by";
+  by_descriptor.description = "The amount to increment/decrement the axis by to when invoked.";
+  parameters->declare_parameter(
+      by_descriptor.name, rclcpp::ParameterValue(0.0),
+      by_descriptor);
+  if (rclcpp::Parameter by_param;
+      parameters->get_parameter(by_descriptor.name, by_param))
+  {
+    params.by = static_cast<float>(by_param.as_double());
+  }
+
+  constexpr double infinity = std::numeric_limits<double>::infinity();
+  const auto default_until = params.by < 0.0 ? -infinity : infinity;
+
+  auto until_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
+  until_descriptor.name = prefix + "until";
+  until_descriptor.description = "The max (or min when 'by' is negative) amount to increment/decrement the axis until when invoked.";
+  parameters->declare_parameter(
+      until_descriptor.name, rclcpp::ParameterValue(default_until),
+      until_descriptor);
+  if (rclcpp::Parameter until_param;
+      parameters->get_parameter(until_descriptor.name, until_param))
+  {
+    params.until = static_cast<float>(until_param.as_double());
+  }
+
+  params_ = params;
+}
+
+void IncrementAxisCommand::execute(CommandDelegate& context, const rclcpp::Time& now)
+{
+  const auto state = context.get_states().get_axes()[params_.name];
+
+  if (!state)
+    return;   //< This should never be possible
+
+  // Do nothing when limit is reached
+  if (params_.by < 0.0 && state->value <= params_.until || params_.by >= 0.0 && state->value >= params_.until)
+    return;
+
+  // increment state->value, while limiting against params_.until, depending on the sign of params_.by
+  if (params_.by < 0.0) {
+    state->value = std::max(state->value + params_.by, params_.until);
+  }
+  else {
+    state->value = std::min(state->value + params_.by, params_.until);
+  }
+}
+
+}  // namespace teleop
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(teleop::IncrementAxisCommand, teleop::Command);

--- a/teleop_core/src/commands/IncrementAxisCommand.cpp
+++ b/teleop_core/src/commands/IncrementAxisCommand.cpp
@@ -15,8 +15,9 @@
 namespace teleop
 {
 
-void IncrementAxisCommand::on_initialize(const std::string& prefix,
-                                         const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& parameters)
+void IncrementAxisCommand::on_initialize(
+  const std::string & prefix,
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & parameters)
 {
   Params params{};
 
@@ -33,10 +34,10 @@ void IncrementAxisCommand::on_initialize(const std::string& prefix,
   by_descriptor.name = prefix + "by";
   by_descriptor.description = "The amount to increment/decrement the axis by to when invoked.";
   parameters->declare_parameter(
-      by_descriptor.name, rclcpp::ParameterValue(0.0),
-      by_descriptor);
+    by_descriptor.name, rclcpp::ParameterValue(0.0),
+    by_descriptor);
   if (rclcpp::Parameter by_param;
-      parameters->get_parameter(by_descriptor.name, by_param))
+    parameters->get_parameter(by_descriptor.name, by_param))
   {
     params.by = static_cast<float>(by_param.as_double());
   }
@@ -46,12 +47,13 @@ void IncrementAxisCommand::on_initialize(const std::string& prefix,
 
   auto until_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
   until_descriptor.name = prefix + "until";
-  until_descriptor.description = "The max (or min when 'by' is negative) amount to increment/decrement the axis until when invoked.";
+  until_descriptor.description =
+    "The max (or min when 'by' is negative) amount to increment/decrement the axis until when invoked.";
   parameters->declare_parameter(
-      until_descriptor.name, rclcpp::ParameterValue(default_until),
-      until_descriptor);
+    until_descriptor.name, rclcpp::ParameterValue(default_until),
+    until_descriptor);
   if (rclcpp::Parameter until_param;
-      parameters->get_parameter(until_descriptor.name, until_param))
+    parameters->get_parameter(until_descriptor.name, until_param))
   {
     params.until = static_cast<float>(until_param.as_double());
   }
@@ -59,22 +61,25 @@ void IncrementAxisCommand::on_initialize(const std::string& prefix,
   params_ = params;
 }
 
-void IncrementAxisCommand::execute(CommandDelegate& context, const rclcpp::Time& now)
+void IncrementAxisCommand::execute(CommandDelegate & context, const rclcpp::Time & now)
 {
   const auto state = context.get_states().get_axes()[params_.name];
 
-  if (!state)
+  if (!state) {
     return;   //< This should never be possible
 
+  }
   // Do nothing when limit is reached
-  if (params_.by < 0.0 && state->value <= params_.until || params_.by >= 0.0 && state->value >= params_.until)
+  if (params_.by < 0.0 && state->value <= params_.until || params_.by >= 0.0 &&
+    state->value >= params_.until)
+  {
     return;
+  }
 
   // increment state->value, while limiting against params_.until, depending on the sign of params_.by
   if (params_.by < 0.0) {
     state->value = std::max(state->value + params_.by, params_.until);
-  }
-  else {
+  } else {
     state->value = std::min(state->value + params_.by, params_.until);
   }
 }

--- a/teleop_core/src/commands/SetAxisCommand.cpp
+++ b/teleop_core/src/commands/SetAxisCommand.cpp
@@ -1,0 +1,55 @@
+// Copyright 2025 Bailey Chessum
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Created by Bailey Chessum on 31/7/25.
+//
+
+#include "teleop_core/commands/SetAxisCommand.hpp"
+
+namespace teleop
+{
+
+void SetAxisCommand::on_initialize(const std::string & prefix,
+                                   const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & parameters)
+{
+  Params params{};
+
+  auto name_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
+  name_descriptor.name = prefix + "name";
+  name_descriptor.description = "The name of the axis to set the value for.";
+  parameters->declare_parameter(name_descriptor.name, rclcpp::ParameterValue(""), name_descriptor);
+  if (rclcpp::Parameter name_param; parameters->get_parameter(name_descriptor.name, name_param)) {
+    params.name = name_param.as_string();
+  }
+
+  auto value_descriptor = rcl_interfaces::msg::ParameterDescriptor{};
+  value_descriptor.name = prefix + "value";
+  value_descriptor.description = "The value to set the axis to when invoked.";
+  parameters->declare_parameter(
+      value_descriptor.name, rclcpp::ParameterValue(0.0),
+      value_descriptor);
+  if (rclcpp::Parameter value_param;
+      parameters->get_parameter(value_descriptor.name, value_param))
+  {
+    params.value = static_cast<float>(value_param.as_double());
+  }
+
+  params_ = params;
+}
+
+void SetAxisCommand::execute(CommandDelegate & context, const rclcpp::Time & now)
+{
+  context.get_states().get_axes().set(params_.name, params_.value);
+}
+
+}  // namespace teleop
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(teleop::SetAxisCommand, teleop::Command);

--- a/teleop_core/src/commands/SetAxisCommand.cpp
+++ b/teleop_core/src/commands/SetAxisCommand.cpp
@@ -15,8 +15,9 @@
 namespace teleop
 {
 
-void SetAxisCommand::on_initialize(const std::string & prefix,
-                                   const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & parameters)
+void SetAxisCommand::on_initialize(
+  const std::string & prefix,
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & parameters)
 {
   Params params{};
 
@@ -32,10 +33,10 @@ void SetAxisCommand::on_initialize(const std::string & prefix,
   value_descriptor.name = prefix + "value";
   value_descriptor.description = "The value to set the axis to when invoked.";
   parameters->declare_parameter(
-      value_descriptor.name, rclcpp::ParameterValue(0.0),
-      value_descriptor);
+    value_descriptor.name, rclcpp::ParameterValue(0.0),
+    value_descriptor);
   if (rclcpp::Parameter value_param;
-      parameters->get_parameter(value_descriptor.name, value_param))
+    parameters->get_parameter(value_descriptor.name, value_param))
   {
     params.value = static_cast<float>(value_param.as_double());
   }

--- a/teleop_modular_twist/plugins.xml
+++ b/teleop_modular_twist/plugins.xml
@@ -14,4 +14,7 @@
     <class name="set_button" type="teleop::SetButtonCommand" base_class_type="teleop::Command">
         <description>A command to set the value of a boolean input.</description>
     </class>
+    <class name="set_axis" type="teleop::SetAxisCommand" base_class_type="teleop::Command">
+        <description>A command to set the value of an axis input.</description>
+    </class>
 </library>

--- a/teleop_modular_twist/plugins.xml
+++ b/teleop_modular_twist/plugins.xml
@@ -17,4 +17,7 @@
     <class name="set_axis" type="teleop::SetAxisCommand" base_class_type="teleop::Command">
         <description>A command to set the value of an axis input.</description>
     </class>
+    <class name="increment_axis" type="teleop::IncrementAxisCommand" base_class_type="teleop::Command">
+        <description>A command to increment/decrement the value of an axis input.</description>
+    </class>
 </library>

--- a/teleop_node/include/teleop_node/teleop_node.hpp
+++ b/teleop_node/include/teleop_node/teleop_node.hpp
@@ -46,7 +46,7 @@ public:
   void service_input_updates();
 
   [[nodiscard]] std::shared_ptr<rclcpp::Node> get_node() const override;
-  [[nodiscard]] const InputManager & get_inputs() const override;
+  [[nodiscard]] InputManager & get_inputs() override;
   [[nodiscard]] state::StateManager & get_states() override;
   [[nodiscard]] const std::shared_ptr<internal::ControlModeManager> get_control_modes() const
   override;

--- a/teleop_node/src/teleop_node.cpp
+++ b/teleop_node/src/teleop_node.cpp
@@ -169,7 +169,7 @@ std::shared_ptr<rclcpp::Node> TeleopNode::get_node() const
   return node_;
 }
 
-const InputManager & TeleopNode::get_inputs() const
+InputManager & TeleopNode::get_inputs()
 {
   return inputs_;
 }

--- a/teleop_node/src/teleop_node.cpp
+++ b/teleop_node/src/teleop_node.cpp
@@ -205,10 +205,8 @@ int main(int argc, char * argv[])
   std::string node_name = "teleop_node";
 
   // Manual CLI parsing to get --node-name
-  for (int i = 1; i < argc; ++i)
-  {
-    if (std::string(argv[i]) == "--node-name" && i + 1 < argc)
-    {
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--node-name" && i + 1 < argc) {
       node_name = argv[i + 1];
       ++i;  // Skip next argv as it's consumed
     }


### PR DESCRIPTION
This PR adds commands to set axis state values:

`set_axis` accepts parameters:
- `name`: (string) the name of the axis to set
- `value`: (double) the value to set the axis to

`increment_axis` accepts parameters:
- `name`: (string) the name of the axis to set
- `by`: (double) the amount to increment (or decrement if negative) the axis by when triggered
- `until` (double) the limit to modify the 
- `log`: (bool) logs changes to the axis when true (true by default)

---

General improvements still need to be made to commands
- Moving the commands `plugin.xml` definitions out of `teleop_modular_twist`, a bodge to fix a weird issue with discovery when splitting up packages to make `teleop_core`. -- maybe this could be solved with a `teleop_modular_commands` package to just contain general command definitions, and any infrastructure to call these commands without using ROS2 parameters
- Exposing a logging interface to the commands in configuration
- Allowing commands to be executed from a ROS2 service
  - Invoking command objects spawned and configured with pluginlib and a param file by sending the name to invoke in a ROS2 service
  - Invoking a temporary command by sending values in a ROS2 message