### PR TITLE
feat: Publish Control Manager State

### DIFF
--- a/teleop_core/CMakeLists.txt
+++ b/teleop_core/CMakeLists.txt
@@ -13,6 +13,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   std_srvs
   control_mode
   input_source
+  teleop_msgs
 )
 
 find_package(ament_cmake REQUIRED)
@@ -61,6 +62,7 @@ add_library(${PROJECT_NAME} SHARED
   src/inputs/input_pipeline_builder.cpp
 
   src/control_modes/controller_manager_manager.cpp
+  src/control_modes/control_mode_manager_state_publisher.cpp
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)  # Require C++17

--- a/teleop_core/default.nix
+++ b/teleop_core/default.nix
@@ -16,6 +16,7 @@
 , teleop-modular-control-mode
 , teleop-modular-input-source
 , rclcpp-lifecycle
+, teleop-modular-msgs
 }:
 
 buildRosPackage {
@@ -59,6 +60,7 @@ buildRosPackage {
     std-msgs
     teleop-modular-control-mode
     teleop-modular-input-source
+    teleop-modular-msgs
     rclcpp-lifecycle
   ];
 

--- a/teleop_core/include/teleop_core/control_modes/control_mode_manager.hpp
+++ b/teleop_core/include/teleop_core/control_modes/control_mode_manager.hpp
@@ -25,6 +25,7 @@
 #include "teleop_core/inputs/input_pipeline_builder.hpp"
 #include "control_mode/event/event_collection.hpp"
 #include "teleop_core/control_modes/controller_manager_manager.hpp"
+#include "teleop_core/control_modes/control_mode_manager_state_publisher.hpp"
 
 namespace teleop::internal
 {
@@ -39,7 +40,7 @@ public:
     const std::shared_ptr<rclcpp::Node> & node,
     const std::weak_ptr<rclcpp::Executor> & executor,
     control_mode::EventCollection & events)
-  : node_(node), executor_(executor), events_(events)
+  : node_(node), executor_(executor), events_(events), state_publisher_(node, *this)
   {
   }
 
@@ -93,6 +94,11 @@ public:
     return control_modes_.end();
   }
 
+  [[nodiscard]] size_t size() const
+  {
+    return control_modes_.size();
+  }
+
   void add(const std::string & key, const std::shared_ptr<control_mode::ControlMode> & value);
 
   void activate_initial_control_modes();
@@ -107,14 +113,14 @@ public:
 
   // TODO: Rename to make clear that these are the inputs we want to consume, not provide
   /**
-     * Allows an element to declare what inputs it CONSUMES, not provides. This is useful for any dynamic remapping of
-     * any previous elements in the pipeline.
-     * \param[in, out] names the set accumulating all declared input names. Add names to declare to this set.
+   * Allows an element to declare what inputs it CONSUMES, not provides. This is useful for any dynamic remapping of
+   * any previous elements in the pipeline.
+   * \param[in, out] names the set accumulating all declared input names. Add names to declare to this set.
    */
   void declare_input_names(InputPipelineBuilder::DeclaredNames& names) override;
 
   /**
-     * Callback ran when hardened inputs are available.
+   * Callback ran when hardened inputs are available.
    */
   void on_inputs_available(InputManager::Hardened& inputs) override;
 
@@ -153,6 +159,8 @@ private:
 
   std::vector<std::shared_ptr<control_mode::ControlMode>> control_modes_by_id_{};
   std::map<std::string, size_t> name_to_cm_id_{};
+
+  ControlModeManagerStatePublisher state_publisher_;
 };
 
 }  // namespace teleop::internal

--- a/teleop_core/include/teleop_core/control_modes/control_mode_manager_state_publisher.hpp
+++ b/teleop_core/include/teleop_core/control_modes/control_mode_manager_state_publisher.hpp
@@ -1,0 +1,95 @@
+// Copyright 2025 Bailey Chessum
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//
+// Created by nova on 21/2/26.
+//
+
+#ifndef TELEOP_MODULAR_CONTROLMODEMANAGER_STATE_PUBLISHER_HPP
+#define TELEOP_MODULAR_CONTROLMODEMANAGER_STATE_PUBLISHER_HPP
+
+#include <string>
+#include <rclcpp/node.hpp>
+#include "control_mode/control_mode.hpp"
+#include <rclcpp/rclcpp/publisher.hpp>
+#include "teleop_msgs/teleop_msgs/msg/control_mode_state.hpp"
+#include "teleop_msgs/teleop_msgs/msg/teleop_state.hpp"
+
+namespace teleop::internal
+{
+
+class ControlModeManager;
+
+/**
+ * Class responsible for publishing the current state of control modes.
+ */
+class ControlModeManagerStatePublisher final
+{
+public:
+  class LockedListener : public control_mode::EventListener {
+  public:
+    bool is_down = false;
+    ControlModeManagerStatePublisher& parent;
+
+    LockedListener(bool is_down, ControlModeManagerStatePublisher& parent) : is_down(is_down), parent(parent) {}
+
+    void on_event_invoked(const rclcpp::Time& now) override;
+  };
+
+  explicit ControlModeManagerStatePublisher(
+    std::shared_ptr<rclcpp::Node> node,
+    ControlModeManager & manager);
+
+  ~ControlModeManagerStatePublisher();
+
+  /**
+   * \brief Exposes inputs to the control mode so that it can capture shared pointers to any inputs it needs. Called
+   * after configure.
+   *
+   * \param inputs References to the collection of buttons and axes to be used by the control_mode.
+   */
+  void configure_inputs(control_mode::Inputs inputs);
+
+  void publish_state(const rclcpp::Time& now);
+  void publish_control_mode_states(const rclcpp::Time& now);
+
+private:
+  /// Helper struct to hold parameters used by the control mode.
+  struct Params {
+    /// The topic name to send TeleopState messages to.
+    std::string state_topic = "";
+
+    /// The topic name to send ControlModeState messages to.
+    std::string control_mode_state_topic = "";
+  };
+
+  /// Stores current parameter values
+  Params params_;
+
+  /// Parent
+  ControlModeManager & manager_;
+
+  /// The owning teleop_modular ROS2 node.
+  std::shared_ptr<rclcpp::Node> node_;
+  /// Locked button reference
+  control_mode::Button locked_;
+
+  std::shared_ptr<LockedListener> up_listener_{std::make_shared<LockedListener>(false, *this)};
+  std::shared_ptr<LockedListener> down_listener_{std::make_shared<LockedListener>(true, *this)};
+
+  /// Publisher for inputs
+  rclcpp::Publisher<teleop_msgs::msg::TeleopState>::SharedPtr state_publisher_;
+  rclcpp::Publisher<teleop_msgs::msg::ControlModeState>::SharedPtr control_mode_publisher_;
+
+  /// List of control mode names
+  std::vector<std::string> control_mode_names_;
+};
+} // namespace teleop::internal
+
+#endif  // TELEOP_MODULAR_CONTROLMODEMANAGER_STATE_PUBLISHER_HPP

--- a/teleop_core/package.xml
+++ b/teleop_core/package.xml
@@ -20,6 +20,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>teleop_msgs</depend>
   <build_depend>control_mode</build_depend>
   <build_export_depend>control_mode</build_export_depend>
   <build_depend>input_source</build_depend>

--- a/teleop_core/src/control_modes/control_mode_manager_state_publisher.cpp
+++ b/teleop_core/src/control_modes/control_mode_manager_state_publisher.cpp
@@ -1,0 +1,121 @@
+// Copyright 2025 Bailey Chessum
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#include "teleop_core/control_modes/control_mode_manager_state_publisher.hpp"
+#include "teleop_core/control_modes/control_mode_manager.hpp"
+
+namespace teleop::internal
+{
+
+namespace
+{
+using control_mode::ControlMode;
+}  // namespace
+
+void ControlModeManagerStatePublisher::LockedListener::on_event_invoked(const rclcpp::Time& now)
+{
+  // This is run whenever the down or up event is invoked
+  parent.publish_state(now);
+}
+
+ControlModeManagerStatePublisher::ControlModeManagerStatePublisher(
+  std::shared_ptr<rclcpp::Node> node,
+  ControlModeManager& manager)
+    : node_(node),
+      manager_(manager)
+{
+  const auto logger = node_->get_logger();
+
+  // Get parameters
+  params_ = Params();
+  auto default_state_topic = std::string(node_->get_name()) + "/locked";
+  node->get_parameter_or<std::string>("locked_topic", params_.state_topic, default_state_topic);
+
+  auto default_control_mode_topic = std::string(node_->get_name()) + "/active_control_modes";
+  node->get_parameter_or<std::string>("active_control_modes_topic", params_.control_mode_state_topic, default_control_mode_topic);
+
+  // QoS settings
+  rclcpp::QoS qos(1);
+  qos.durability(rclcpp::DurabilityPolicy::TransientLocal);
+  qos.reliable();
+
+  // Create publisher
+  state_publisher_ = node->create_publisher<teleop_msgs::msg::TeleopState>(params_.state_topic, qos);
+  control_mode_publisher_ = node->create_publisher<teleop_msgs::msg::ControlModeState>(params_.control_mode_state_topic, qos);
+}
+ControlModeManagerStatePublisher::~ControlModeManagerStatePublisher()
+{
+  auto now = node_->now();
+
+  // Publish inactive message when shutting down.
+  auto msg = std::make_unique<teleop_msgs::msg::TeleopState>();
+  msg->header.stamp = now;
+  msg->active = false;
+  state_publisher_->publish(std::move(msg));
+
+  // publish input names and active status
+  auto msg_cm = std::make_unique<teleop_msgs::msg::ControlModeState>();
+  msg_cm->header.stamp = now;
+  msg_cm->names = control_mode_names_;
+  msg_cm->active.reserve(manager_.size());
+
+  for (auto & [name, control_mode] : manager_)
+  {
+    msg_cm->active.emplace_back(false);
+  }
+  control_mode_publisher_->publish(std::move(msg_cm));
+}
+
+void ControlModeManagerStatePublisher::configure_inputs(control_mode::Inputs inputs)
+{
+  locked_ = inputs.buttons["locked"];
+
+  inputs.events["locked/down"]->subscribe(down_listener_);
+  inputs.events["locked/up"]->subscribe(up_listener_);
+}
+
+void ControlModeManagerStatePublisher::publish_state(const rclcpp::Time& now)
+{
+  auto msg = std::make_unique<teleop_msgs::msg::TeleopState>();
+  msg->header.stamp = now;
+  msg->active = true;
+  msg->locked = locked_.value();
+
+  state_publisher_->publish(std::move(msg));
+}
+
+void ControlModeManagerStatePublisher::publish_control_mode_states(const rclcpp::Time& now)
+{
+  // Record names first time publishing.
+  if (control_mode_names_.empty())
+  {
+    control_mode_names_.reserve(manager_.size());
+
+    for (auto & [name, control_mode] : manager_)
+    {
+      control_mode_names_.emplace_back(name);
+    }
+  }
+
+  // publish input names and active status
+  auto msg = std::make_unique<teleop_msgs::msg::ControlModeState>();
+  msg->header.stamp = now;
+  msg->names = control_mode_names_;
+  msg->active.reserve(manager_.size());
+
+  for (auto & [name, control_mode] : manager_)
+  {
+    msg->active.emplace_back(control_mode->is_active());
+  }
+
+  control_mode_publisher_->publish(std::move(msg));
+}
+
+}  // namespace teleop::internal

--- a/teleop_msgs/CMakeLists.txt
+++ b/teleop_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/InvokedEvents.msg
   msg/CombinedInputs.msg
   msg/CombinedInputValues.msg
+  msg/TeleopState.msg
 
   DEPENDENCIES std_msgs
 )

--- a/teleop_msgs/msg/ControlModeState.msg
+++ b/teleop_msgs/msg/ControlModeState.msg
@@ -1,5 +1,6 @@
-# A component could be a control mode, input source, or other
+# Current state of all control modes.
 
-bool active    # Whether the components state is active
-string state
+std_msgs/Header header    # timestamp in the header is the time of the last change
 
+string[] names            # List of control modes.
+bool[] active             # Whether each of those control modes is active.

--- a/teleop_msgs/msg/TeleopState.msg
+++ b/teleop_msgs/msg/TeleopState.msg
@@ -1,0 +1,6 @@
+# This message contains the current state of Teleop.
+
+std_msgs/Header header            # timestamp in the header is the time of the last change
+
+bool active                       # Status of Teleop.
+bool locked                       # Locked status.


### PR DESCRIPTION
## Summary

Add telemetry publishing to the control manager. Will now publish whether the locked status of a teleop system and which control modes are active.

TODO
Figure out how to clear the messages when teleop is ctrl-c ed so that we can say things are no longer active.

## ROS2

Publishes teleop_msgs ControlModeState and TeleopState to the topics `/<name_of_teleop_node>/active_control_modes` and `/<name of teleop node>/state` respectively, until the topic is set as a parameter. 

## Screenshots

Publishing locked status:
[Screencast From 2026-02-21 18-20-05.webm](https://github.com/user-attachments/assets/1521b806-36ef-41f6-b1f1-1724d9556fa1)

Publishing active control modes:
[Screencast From 2026-02-21 18-21-22.webm](https://github.com/user-attachments/assets/e8435ff1-3805-4eed-bc68-7c14eb0513da)
